### PR TITLE
Homepage body layout stephen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
         "@types/node": "^16.18.76",
-        "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
         "bootstrap": "^5.3.2",
         "gh-pages": "^6.1.1",
@@ -21,9 +20,13 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.10.1",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.22.3",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@types/react": "^18.2.74"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3126,6 +3129,14 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@restart/hooks": {
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
@@ -3854,12 +3865,11 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.60",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.60.tgz",
-      "integrity": "sha512-dfiPj9+k20jJrLGOu9Nf6eqxm2EyJRrq2NvwOFsfbb7sFExZ9WELPs67UImHj3Ayxg8ruTtKtNnbjaF8olPq0A==",
+      "version": "18.2.74",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.74.tgz",
+      "integrity": "sha512-9AEqNZZyBx8OdZpxzQlaFEVCSFUM2YXJH46yPOiOpm078k6ZLOCcuAzGum/zK8YBwY+dbahVNbHrbgrAwIRlqw==",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -3891,11 +3901,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -5272,12 +5277,12 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -5285,7 +5290,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -5912,9 +5917,9 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -7880,16 +7885,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -8178,9 +8183,9 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -13549,9 +13554,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -13801,6 +13806,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
+      "dependencies": {
+        "@remix-run/router": "1.15.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
+      "dependencies": {
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {
@@ -16316,9 +16351,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dependencies": {
         "colorette": "^2.0.10",
         "memfs": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.18.76",
-    "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "bootstrap": "^5.3.2",
     "gh-pages": "^6.1.1",
@@ -16,6 +15,7 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.10.1",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
@@ -45,5 +45,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.74"
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -13,7 +13,7 @@
   }
 }
 
-.App-header {
+.App-body {
   background-color: #282c34;
   min-height: 100vh;
   display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from "react";
+import React from "react";
 import "./App.css";
-import { Button, Form } from "react-bootstrap";
 import { HashRouter as Router, Routes, Route } from "react-router-dom";
 import HomeScreen from "./Pages/HomeScreen";
 import DetailedTestScreen from "./Pages/DetailedTest";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,46 +1,28 @@
 import React, { useState } from "react";
 import "./App.css";
 import { Button, Form } from "react-bootstrap";
+import { HashRouter as Router, Routes, Route } from "react-router-dom";
 import HomeScreen from "./Pages/HomeScreen";
+import DetailedTestScreen from "./Pages/DetailedTest";
+import BasicTestScreen from "./Pages/BasicTest";
 
-//local storage and API Key: key should be entered in by the user and will be stored in local storage (NOT session storage)
-let keyData = "";
-const saveKeyData = "MYKEY";
-const prevKey = localStorage.getItem(saveKeyData); //so it'll look like: MYKEY: <api_key_value here> in the local storage when you inspect
-if (prevKey !== null) {
-  keyData = JSON.parse(prevKey);
-}
 
 function App() {
-  const [key, setKey] = useState<string>(keyData); //for api key input
-
-  //sets the local storage item to the api key the user inputed
-  function handleSubmit() {
-    localStorage.setItem(saveKeyData, JSON.stringify(key));
-    window.location.reload(); //when making a mistake and changing the key again, I found that I have to reload the whole site before openai refreshes what it has stores for the local storage variable
-  }
-
-  //whenever there's a change it'll store the api key in a local state called key but it won't be set in the local storage until the user clicks the submit button
-  function changeKey(event: React.ChangeEvent<HTMLInputElement>) {
-    setKey(event.target.value);
-  }
-  return (
-    <div className="App">
-      <HomeScreen></HomeScreen>
-      <Form>
-        <Form.Label>API Key:</Form.Label>
-        <Form.Control
-          type="password"
-          placeholder="Insert API Key Here"
-          onChange={changeKey}
-        ></Form.Control>
-        <br></br>
-        <Button className="Submit-Button" onClick={handleSubmit}>
-          Submit
-        </Button>
-      </Form>
-    </div>
-  );
+    /**
+     * The "main" function of the application. Primarily used to route the user to the appropriate page.
+     * @author Stephen Sayers
+     */
+    return (
+        <div className="App">
+            <Router>
+                <Routes>
+                    <Route path="/" element={<HomeScreen/>}/>
+                    <Route path="/basic-test" element={<BasicTestScreen/>}/>
+                    <Route path="/detailed-test" element={<DetailedTestScreen/>}/>
+                </Routes>
+            </Router>
+        </div>
+    )
 }
 
 export default App;

--- a/src/CSS/HomeScreen.css
+++ b/src/CSS/HomeScreen.css
@@ -1,5 +1,7 @@
 .Text-blurb {
-    text-align: start
+  padding-top: 6vh;
+  max-width: 75vw;
+  text-align: start
 }
 
 .Home-body {
@@ -7,8 +9,7 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
+  justify-content: start;
   font-size: calc(10px + 2vmin);
   color: white;
 }

--- a/src/CSS/HomeScreen.css
+++ b/src/CSS/HomeScreen.css
@@ -1,0 +1,14 @@
+.Text-blurb {
+    text-align: start
+}
+
+.Home-body {
+  background-color: #282c34;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+}

--- a/src/Pages/BasicTest.tsx
+++ b/src/Pages/BasicTest.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+
+export default function BasicTestScreen() {
+    return (
+        <div>
+            <h1>This is a placeholder for the basic test.</h1>
+        </div>
+    )
+}

--- a/src/Pages/DetailedTest.tsx
+++ b/src/Pages/DetailedTest.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+
+export default function DetailedTestScreen() {
+    return (
+        <div>
+            <h1>This is a placeholder for the detailed test.</h1>
+        </div>
+    )
+}

--- a/src/Pages/HomeScreen.tsx
+++ b/src/Pages/HomeScreen.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from "react";
 import {Button, Form} from "react-bootstrap";
 import { Link } from "react-router-dom";
+import "../CSS/HomeScreen.css";
 
 
 //local storage and API Key: key should be entered in by the user and will be stored in local storage (NOT session storage)
@@ -37,8 +38,8 @@ function TestBlurb({header, textBody, linkText, link}: {header: string; textBody
      * @param link {string} - The link that brings the user to the test
      */
     return (
-        <div>
-            <h3>{header}</h3>
+        <div className="Text-blurb">
+            <h2>{header}</h2>
             <p>{textBody}</p>
             <Link to={link}>{linkText}</Link>
         </div>
@@ -59,9 +60,9 @@ export default function HomeScreen() {
     setKey(event.target.value);
   }
   return (
-    <div className="App">
-      <Header></Header>
-      <div className="App-body">
+    <div>
+      <Header/>
+      <div className="Home-body">
         <TestBlurb
             header={"Basic Test"}
             textBody={"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut " +
@@ -71,6 +72,7 @@ export default function HomeScreen() {
             linkText={"Take the Basic Test"}
             link={"/basic-test"}
         />
+        <p style={{paddingBottom: "1px"}}/> <p/>{/*adds some space for aesthetics*/}
         <TestBlurb
             header={"Detailed Test"}
             textBody={"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut " +

--- a/src/Pages/HomeScreen.tsx
+++ b/src/Pages/HomeScreen.tsx
@@ -1,6 +1,18 @@
-import React from "react";
+import React, {useState} from "react";
+import {Button, Form} from "react-bootstrap";
+import { Link } from "react-router-dom";
 
-export default function HomeScreen() {
+
+//local storage and API Key: key should be entered in by the user and will be stored in local storage (NOT session storage)
+let keyData = "";
+const saveKeyData = "MYKEY";
+const prevKey = localStorage.getItem(saveKeyData); //so it'll look like: MYKEY: <api_key_value here> in the local storage when you inspect
+if (prevKey !== null) {
+  keyData = JSON.parse(prevKey);
+}
+
+
+function Header() {
   return (
     <header className="container">
       <div className="header">
@@ -10,5 +22,77 @@ export default function HomeScreen() {
         <a href="#about">About</a>
       </div>
     </header>
+  );
+}
+
+
+function TestBlurb({header, textBody, linkText, link}: {header: string; textBody: string; linkText: string; link: string;}): JSX.Element {
+    /**
+     * JSX element that displays the title of a test, a paragraph describing the test, and a link to the test.
+     *@author Stephen Sayers
+     *
+     * @param header {string} - used to display the name of the test
+     * @param textBody {string} - used to describe what the test is about
+     * @param linkText {string} - The text of the link that brings the user to the test
+     * @param link {string} - The link that brings the user to the test
+     */
+    return (
+        <div>
+            <h3>{header}</h3>
+            <p>{textBody}</p>
+            <Link to={link}>{linkText}</Link>
+        </div>
+    )
+}
+
+export default function HomeScreen() {
+  const [key, setKey] = useState<string>(keyData); //for api key input
+
+  //sets the local storage item to the api key the user inputted
+  function handleSubmit() {
+    localStorage.setItem(saveKeyData, JSON.stringify(key));
+    window.location.reload(); //when making a mistake and changing the key again, I found that I have to reload the whole site before openai refreshes what it has stores for the local storage variable
+  }
+
+  //whenever there's a change it'll store the api key in a local state called key but it won't be set in the local storage until the user clicks the submit button
+  function changeKey(event: React.ChangeEvent<HTMLInputElement>) {
+    setKey(event.target.value);
+  }
+  return (
+    <div className="App">
+      <Header></Header>
+      <div className="App-body">
+        <TestBlurb
+            header={"Basic Test"}
+            textBody={"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut " +
+                "labore et dolore magna aliqua. Aliquet lectus proin nibh nisl condimentum id. Vestibulum morbi " +
+                "blandit cursus risus at ultrices. Vel quam elementum pulvinar etiam non quam. Ut sem nulla pharetra " +
+                "diam sit amet nisl suscipit. Nisi lacus sed viverra tellus in hac habitasse."}
+            linkText={"Take the Basic Test"}
+            link={"/basic-test"}
+        />
+        <TestBlurb
+            header={"Detailed Test"}
+            textBody={"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut " +
+                "labore et dolore magna aliqua. Aliquet lectus proin nibh nisl condimentum id. Vestibulum morbi " +
+                "blandit cursus risus at ultrices. Vel quam elementum pulvinar etiam non quam. Ut sem nulla pharetra " +
+                "diam sit amet nisl suscipit. Nisi lacus sed viverra tellus in hac habitasse."}
+            linkText={"Take the Detailed Test"}
+            link={"/detailed-test"}
+        />
+      </div>
+      <Form>
+        <Form.Label>API Key:</Form.Label>
+        <Form.Control
+          type="password"
+          placeholder="Insert API Key Here"
+          onChange={changeKey}
+        ></Form.Control>
+        <br></br>
+        <Button className="Submit-Button" onClick={handleSubmit}>
+          Submit
+        </Button>
+      </Form>
+    </div>
   );
 }

--- a/src/Pages/HomeScreen.tsx
+++ b/src/Pages/HomeScreen.tsx
@@ -14,13 +14,16 @@ if (prevKey !== null) {
 
 
 function Header() {
-  return (
+    /**
+     * JSX element that renders a header that appears at the top of all pages.
+     */
+    return (
     <header className="container">
       <div className="header">
-        <a href="#home">Home</a>
-        <a href="#news">News</a>
-        <a href="#contact">Contact</a>
-        <a href="#about">About</a>
+        <Link to="/">Home</Link>
+        <Link to="/">News</Link>
+        <Link to="/">Contact</Link>
+        <Link to="/">About</Link>
       </div>
     </header>
   );
@@ -52,7 +55,7 @@ export default function HomeScreen() {
   //sets the local storage item to the api key the user inputted
   function handleSubmit() {
     localStorage.setItem(saveKeyData, JSON.stringify(key));
-    window.location.reload(); //when making a mistake and changing the key again, I found that I have to reload the whole site before openai refreshes what it has stores for the local storage variable
+    window.location.reload();//when making a mistake and changing the key again, I found that I have to reload the whole site before openai refreshes what it has stores for the local storage variable
   }
 
   //whenever there's a change it'll store the api key in a local state called key but it won't be set in the local storage until the user clicks the submit button
@@ -72,7 +75,7 @@ export default function HomeScreen() {
             linkText={"Take the Basic Test"}
             link={"/basic-test"}
         />
-        <p style={{paddingBottom: "1px"}}/> <p/>{/*adds some space for aesthetics*/}
+
         <TestBlurb
             header={"Detailed Test"}
             textBody={"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut " +


### PR DESCRIPTION
- Moved all of the website's pages into their own .tsx file.
- converts App.tsx from being the home page into a function for routing the pages of the site
- a new JTX element: TestBlurb() was created so the formatting for the basic test and detailed test would be the same 
- the HTML of the homepage was modified to include the TestBlurb() calls for the basic test and the detailed test. Dummy text was used for the body of the two calls.
- HomeScreen() has been slightly modified due to the switch over to React Router (to be able to run the site locally type "npm i react-router-dom" into the terminal to install the router, then you can run "npm start" like normal) 
- HomeScreen() has been renamed to Header() to avoid confusion with the element rendering the home page.