### PR TITLE
Major Filtering

### DIFF
--- a/src/Components/progress.tsx
+++ b/src/Components/progress.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from "react-router-dom";
-import { ProgressBar, Button } from 'react-bootstrap';
+import {ProgressBar, Button, Form} from 'react-bootstrap';
 import { questionJsonProps } from "./Question";
 import "../CSS/Progress.css";
 import '../CSS/Tests.css'
@@ -23,20 +23,22 @@ export function QuizProgressBar({answeredCount, num_questions}: {
 }
 
 
-function exportResults(questions: Array<questionJsonProps>, responses: Array<string>): string {
-    /**
-     * takes the questions and responses and combines the text of the question with its response, used in <FinishScreen>
-     * to pass on the results of the test to the OpenAI API
-     *@author Stephen
-     *
-     * @param questions the array of the questions that were asked to the user
-     * @param responses the users responses, its expected that the responses are the same length as questions
-     */
+/**
+ * takes the questions and responses and combines the text of the question with its response, used in <FinishScreen>
+ * to pass on the results of the test to the OpenAI API
+ *@author Stephen
+ *
+ * @param questions the array of the questions that were asked to the user
+ * @param responses the users responses, its expected that the responses are the same length as questions
+ * @param major the major that the user entered in FinishScreen, isn't added onto the results if the user entered nothing
+ */
+function exportResults(questions: Array<questionJsonProps>, responses: Array<string>, major: string): string {
     let results: string = ""
     for (let i = 0; i < questions.length; i++) { // I don't even know how you could use the string methods for this
         results += ("Q" + (i + 1).toString() + ": " + questions[i].questionText + "\n");
         results += ("A" + (i + 1).toString() + ": " + responses[i] + "\n\n");
     }
+    if (major.length > 0) {results += "The test taker only wants careers from these major(s) " + major + "\n"}
 
     console.log(results);
 
@@ -44,18 +46,20 @@ function exportResults(questions: Array<questionJsonProps>, responses: Array<str
 }
 
 
+/**
+ * When a test is finished this element takes the place of the question box to alert the user that they can go on to
+ * the results of the test
+ * @author Stephen
+ *
+ */
 export function FinishScreen({setIndex, questions, responses}: {
     setIndex: React.Dispatch<React.SetStateAction<number>>,
     questions: Array<questionJsonProps>,
     responses: Array<string>;
 }): JSX.Element {
-    /**
-     * When a test is finished this element takes the place of the question box to alert the user that they can go on to
-     * the results of the test
-     * @author Stephen
-     *
-     */
+    const [major, setMajor] = React.useState<string>("");
     const navigate = useNavigate();
+    function changeMajor(event: React.ChangeEvent<HTMLInputElement>) {setMajor(event.target.value);}
 
     return (
         <div className="question-container"> {/* Takes the place of the question container*/}
@@ -66,8 +70,15 @@ export function FinishScreen({setIndex, questions, responses}: {
                 comprehensive insights into your strengths, preferences, and potential career paths. when you're
                 ready, click below to uncover the personalized results that await you.
             </p>
+            <Form>
+                <Form.Label>Would you like us to only pick careers for a certain major or majors?:</Form.Label>
+                <Form.Control
+                    placeholder="Insert majors here or leave blank"
+                    onChange={changeMajor}
+                />
+            </Form>
             <div className="finish-button-container">
-                <Button className="finish-button" onClick={() => navigate("/results", {state: exportResults(questions, responses)})}>
+                <Button className="finish-button" onClick={() => navigate("/results", {state: exportResults(questions, responses, major)})}>
                     Take me to the results
                 </Button>
                 <Button className="finish-button" onClick={() => setIndex(0)}>


### PR DESCRIPTION
## What's Different
- The finish screen has a text box to make ChatGPT only suggest careers that can be gotten with an entered major
- Changed ExportResults in progress.tsx to tack on the majors to the end of the results

## What the site looks like
![image](https://github.com/dsavage0214/Final_Project_CISC275/assets/159174091/0dc15434-c8ac-4aca-92a5-8e1a0cc16b3f)
What the finish screen looks like now

![image](https://github.com/dsavage0214/Final_Project_CISC275/assets/159174091/c120de6a-1251-4aae-a98e-983398ce6e36)
results gotten when I asked chatGPT to only give me careers for a computer science major or a geology major